### PR TITLE
Playerfischevent, Cooktime and add Sapling to Event

### DIFF
--- a/src/pocketmine/block/Sapling.php
+++ b/src/pocketmine/block/Sapling.php
@@ -28,6 +28,7 @@ use pocketmine\level\generator\object\Tree;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
 use pocketmine\utils\Random;
+use pocketmine\event\block\BlockGrowEvent;
 use function mt_rand;
 
 class Sapling extends Flowable{
@@ -70,7 +71,13 @@ class Sapling extends Flowable{
 	public function onActivate(Item $item, Player $player = null) : bool{
 		if($item->getId() === Item::DYE and $item->getDamage() === 0x0F){ //Bonemeal
 			//TODO: change log type
-			Tree::growTree($this->getLevelNonNull(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->getVariant());
+			#add BlockGrowEvent
+			$block = clone $this;
+			$ev = new BlockGrowEvent($this, $block);
+			$ev->call();
+			if(!$ev->isCancelled()){
+			    Tree::growTree($this->getLevelNonNull(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->getVariant());
+			}
 
 			$item->pop();
 
@@ -93,7 +100,12 @@ class Sapling extends Flowable{
 	public function onRandomTick() : void{
 		if($this->level->getFullLightAt($this->x, $this->y, $this->z) >= 8 and mt_rand(1, 7) === 1){
 			if(($this->meta & 0x08) === 0x08){
-				Tree::growTree($this->getLevelNonNull(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->getVariant());
+				$block = clone $this;
+				$ev = new BlockGrowEvent($this, $block);
+			        $ev->call();
+			        if(!$ev->isCancelled()){
+				    Tree::growTree($this->getLevelNonNull(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->getVariant());
+			        }
 			}else{
 				$this->meta |= 0x08;
 				$this->getLevelNonNull()->setBlock($this, $this, true);

--- a/src/pocketmine/entity/projectile/FishingHook.php
+++ b/src/pocketmine/entity/projectile/FishingHook.php
@@ -284,7 +284,7 @@ class FishingHook extends Projectile{
 		$angler = $this->getOwningEntity();
 		if($this->isValid() and $angler instanceof Player){
 			if($this->getRidingEntity() != null){
-				$ev = new PlayerFishEvent($angler, $this, PlayerFishEvent::STATE_CAUGHT_ENTITY);
+				$ev = new PlayerFishEvent($angler, $this, PlayerFishEvent::STATE_CAUGHT_ENTITY, null, null, null);
 				$ev->call();
 
 				if(!$ev->isCancelled()){
@@ -297,16 +297,30 @@ class FishingHook extends Projectile{
 				}
 			}elseif($this->ticksCatchable > 0){
 				// TODO: Random weighted items
-				$items = [
-					Item::RAW_FISH, Item::PUFFERFISH, Item::RAW_SALMON, Item::CLOWNFISH
-				];
+				$rndCatch = mt_rand(0, 100);
+				if($rndCatch < 81){
+				    $items = [
+					    Item::RAW_FISH, Item::PUFFERFISH, Item::RAW_SALMON, Item::CLOWNFISH
+				    ];
+				}elseif($rndCatch < 101){
+					$items = [
+					    Item::CLOCK, Item::COMPASS, Item::FLINT_STEEL, Item::GLASS_BOTTLE, Item::LEATHER_BOOTS, Item::ROTTEN_FLESH, Item::STICK, Item::FISHING_ROD, Item::RABBIT_FOOT, Item::EXPERIENCE_BOTTLE, Item::DEAD_BUSH, Item::BUCKET, Item::BONE, Item::FLOWER_POT
+				    ];
+				}
 				$randomFish = $items[mt_rand(0, count($items) - 1)];
 				$result = ItemFactory::get($randomFish);
 
+				$name = null;
+				$lore = null;
+
 				$ev = new PlayerFishEvent($angler, $this, PlayerFishEvent::STATE_CAUGHT_FISH, $this->random->nextBoundedInt(6) + 1);
+				$ev = new PlayerFishEvent($angler, $this, PlayerFishEvent::STATE_CAUGHT_FISH, $result, $name, $lore, $this->random->nextBoundedInt(6) + 1);
 				$ev->call();
 
 				if(!$ev->isCancelled()){
+					$result = $ev->getResult();
+					$name = $ev->getName();
+				        $lore = $ev->getLore();
 					$nbt = Entity::createBaseNBT($this);
 					$nbt->setTag($result->nbtSerialize(-1, "Item"));
 
@@ -318,6 +332,12 @@ class FishingHook extends Projectile{
 					$d8 = 0.1;
 					$entityitem->setMotion(new Vector3($d0 * $d8, $d2 * $d8 + sqrt($d6) * 0.08, $d4 * $d8));
 					$entityitem->spawnToAll();
+					if($name !== null){
+					    $entityitem->getItem()->setCustomName($name);
+					}
+					if($lore !== null){
+					    $entityitem->getItem()->setLore([$lore]);
+					}
 					$this->level->dropExperience($angler, $ev->getXpDropAmount());
 				}
 			}

--- a/src/pocketmine/event/inventory/FurnaceCookEvent.php
+++ b/src/pocketmine/event/inventory/FurnaceCookEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\inventory;
+
+use pocketmine\event\block\BlockEvent;
+use pocketmine\event\Cancellable;
+use pocketmine\item\Item;
+use pocketmine\tile\Furnace;
+
+class FurnaceCookEvent extends BlockEvent implements Cancellable{
+	/** @var Furnace */
+	private $furnace;
+	/** @var int */
+	private $maxCookTime;
+
+
+	public function __construct(Furnace $furnace, int $maxCookTime){
+		parent::__construct($furnace->getBlock());	
+		$this->maxCookTime = $maxCookTime;
+		$this->furnace = $furnace;
+	}
+
+	public function getFurnace() : Furnace{
+		return $this->furnace;
+	}
+
+	public function getMaxCookTime() : int{
+		return $this->maxCookTime;
+	}
+
+	public function setMaxCookTime(int $maxCookTime) : void{
+		$this->maxCookTime = $maxCookTime;
+	}
+}

--- a/src/pocketmine/event/player/PlayerFishEvent.php
+++ b/src/pocketmine/event/player/PlayerFishEvent.php
@@ -41,13 +41,45 @@ class PlayerFishEvent extends PlayerEvent implements Cancellable{
 	protected $xpDropAmount = 0;
 	/** @var int */
 	protected $state = 0;
+	
+	protected $result;
 
-	public function __construct(Player $fisher, FishingHook $hook, int $state, int $xpDropAmount = 0){
+	protected $name = null;
+
+	protected $lore = null;
+
+	public function __construct(Player $fisher, FishingHook $hook, int $state, $result, $name, $lore, int $xpDropAmount = 0){
 		$this->player = $fisher;
 		$this->hook = $hook;
 		$this->state = $state;
 		$this->xpDropAmount = $xpDropAmount;
+		$this->result = $result;
+		$this->name = $name;
+		$this->lore = $lore;
 	}
+
+	public function getResult(){
+		return $this->result;
+	}
+
+	public function setResult($result){
+		$this->result = $result;
+	}
+
+	public function getName(){
+		return $this->name;
+	}
+
+	public function setName($name){
+		$this->name = $name;
+	}
+
+	public function getLore(){
+		return $this->lore;
+	}
+
+	public function setLore($lore){
+		$this->lore = $lore;
 
 	public function getCaughtEntity() : ?Entity{
 		return $this->hook->getRidingEntity();

--- a/src/pocketmine/item/FishingRod.php
+++ b/src/pocketmine/item/FishingRod.php
@@ -50,7 +50,7 @@ class FishingRod extends Tool{
 	public function onClickAir(Player $player, Vector3 $directionVector) : bool{
 		if($player->getFishingHook() === null){
 			$hook = new FishingHook($player->level, Entity::createBaseNBT($player->add(0, $player->getEyeHeight() - 0.1, 0), $player->getDirectionVector()->multiply(0.4)), $player);
-			($ev = new PlayerFishEvent($player, $hook, PlayerFishEvent::STATE_FISHING))->call();
+			($ev = new PlayerFishEvent($player, $hook, PlayerFishEvent::STATE_FISHING, null, null, null))->call();
 			if($ev->isCancelled()){
 				$hook->flagForDespawn();
 			}else{

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -27,6 +27,7 @@ use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\event\inventory\FurnaceBurnEvent;
 use pocketmine\event\inventory\FurnaceSmeltEvent;
+use pocketmine\event\inventory\FurnaceCookEvent;
 use pocketmine\inventory\FurnaceInventory;
 use pocketmine\inventory\FurnaceRecipe;
 use pocketmine\inventory\Inventory;
@@ -181,14 +182,22 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		if($this->burnTime <= 0 and $canSmelt and $fuel->getFuelTime() > 0 and $fuel->getCount() > 0){
 			$this->checkFuel($fuel);
 		}
+		$maxCookTime = 200;
 
 		if($this->burnTime > 0){
 			--$this->burnTime;
 
 			if($smelt instanceof FurnaceRecipe and $canSmelt){
-				++$this->cookTime;
+				$event = new FurnaceCookEvent($this, $maxCookTime);
+				$event->call();
 
-				if($this->cookTime >= 200){ //10 seconds
+				$maxCookTime = $event->getMaxCookTime();
+
+				if(!$event->isCancelled()){
+				    ++$this->cookTime;
+				}
+
+				if($this->cookTime >= $maxCookTime){ //10 seconds
 					$product = ItemFactory::get($smelt->getResult()->getId(), $smelt->getResult()->getDamage(), $product->getCount() + 1);
 
 					$ev = new FurnaceSmeltEvent($this, $raw, $product);
@@ -200,7 +209,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 						$this->inventory->setSmelting($raw);
 					}
 
-					$this->cookTime -= 200;
+					$this->cookTime -= $maxCookTime;
 				}
 			}elseif($this->burnTime <= 0){
 				$this->burnTime = $this->cookTime = $this->maxTime = 0;
@@ -220,7 +229,9 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		if($prevCookTime !== $this->cookTime){
 			$pk = new ContainerSetDataPacket();
 			$pk->property = ContainerSetDataPacket::PROPERTY_FURNACE_TICK_COUNT;
-			$pk->value = $this->cookTime;
+			$percent = round(($maxCookTime * 100) / 200); #% of the maxcooktime
+		        $realTime = round(($this->cookTime * 100) / $percent);
+		        $pk->value = (int)$realTime;
 			$packets[] = $pk;
 		}
 


### PR DESCRIPTION
## Introduction
It is easy to make custom Fisch Name or add new items to catch.
It is easy to make custom furnace now.
Now you can chancel the sapling grow with blockgrowevent.

### Relevant issues
#68 and #64

## Changes
### API changes
no

### Behavioural changes
no

## Backwards compatibility
yes compatible

## Tests
I test it on my own network.
