### PR TITLE
fix(entity): address player inventory on mounts and boat player drowning issues

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -41,6 +41,7 @@ use pocketmine\entity\InvalidSkinException;
 use pocketmine\entity\Living;
 use pocketmine\entity\object\ItemEntity;
 use pocketmine\entity\passive\AbstractHorse;
+use pocketmine\entity\PlayerInventoryMount;
 use pocketmine\entity\projectile\Arrow;
 use pocketmine\entity\projectile\FishingHook;
 use pocketmine\entity\Skin;
@@ -2763,7 +2764,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				$this->lastPlayerAuthInputPitch = $packet->getPitch();
 			}
 
-			if (!$rawPos->equals($this->lastPlayerAuthInputPosition !== null ? $this->lastPlayerAuthInputPosition : new Vector3(0, 0, 0))) {
+			if (!$rawPos->equals($this->lastPlayerAuthInputPosition !== null ? $this->lastPlayerAuthInputPosition : new Vector3(0, 0, 0))){
 				$this->handleMovement($newPos);
 				$this->lastPlayerAuthInputPosition = $rawPos;
 
@@ -2771,7 +2772,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 					$ent = $this->getRidingEntity();
 					$vehicle = $packet->getVehicleInfo();
 
-					if (!$inputFlags->get(PlayerAuthInputFlags::START_JUMPING)) {
+					if(!$inputFlags->get(PlayerAuthInputFlags::START_JUMPING)){
 						if($ent instanceof Boat && $vehicle !== null && $vehicle->getPredictedVehicleActorUniqueId() === $ent->getId()){
 							$ent->setClientPositionAndRotation($packet->getPosition(), ($ent->getYaw() + 90) % 360, 0, 3, true);
 						}
@@ -3296,7 +3297,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			case InteractPacket::ACTION_MOUSEOVER:
 				break; //TODO: handle these
 			case InteractPacket::ACTION_OPEN_INVENTORY:
-				if($target === $this && !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID, $this->openHardcodedWindows)){
+				if(($target === $this || $this->ridingEid === $packet->target && $target instanceof PlayerInventoryMount) && !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID, $this->openHardcodedWindows)){
 					//TODO: HACK! this restores 1.14ish behaviour, but this should be able to be listened to and
 					//controlled by plugins. However, the player is always a subscriber to their own inventory so it
 					//doesn't integrate well with the regular container system right now.

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3297,7 +3297,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			case InteractPacket::ACTION_MOUSEOVER:
 				break; //TODO: handle these
 			case InteractPacket::ACTION_OPEN_INVENTORY:
-				if(($target === $this || $this->ridingEid === $packet->target && $target instanceof PlayerInventoryMount) && !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID, $this->openHardcodedWindows)){
+				if(($target === $this || ($this->ridingEid === $packet->target && $target instanceof PlayerInventoryMount)) && !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID, $this->openHardcodedWindows)){
 					//TODO: HACK! this restores 1.14ish behaviour, but this should be able to be listened to and
 					//controlled by plugins. However, the player is always a subscriber to their own inventory so it
 					//doesn't integrate well with the regular container system right now.

--- a/src/pocketmine/entity/PlayerInventoryMount.php
+++ b/src/pocketmine/entity/PlayerInventoryMount.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+interface PlayerInventoryMount{
+
+}

--- a/src/pocketmine/entity/passive/Pig.php
+++ b/src/pocketmine/entity/passive/Pig.php
@@ -33,6 +33,7 @@ use pocketmine\entity\behavior\PanicBehavior;
 use pocketmine\entity\behavior\RandomLookAroundBehavior;
 use pocketmine\entity\behavior\RandomStrollBehavior;
 use pocketmine\entity\behavior\TemptBehavior;
+use pocketmine\entity\PlayerInventoryMount;
 use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\math\Vector3;
@@ -41,7 +42,7 @@ use function boolval;
 use function intval;
 use function rand;
 
-class Pig extends Animal{
+class Pig extends Animal implements PlayerInventoryMount{
 
 	public const NETWORK_ID = self::PIG;
 

--- a/src/pocketmine/entity/vehicle/Boat.php
+++ b/src/pocketmine/entity/vehicle/Boat.php
@@ -95,6 +95,7 @@ class Boat extends Vehicle implements PlayerInventoryMount{
 			$this->setPositionAndRotation($pos, $yaw, $pitch);
 			$this->clientMoveTicks = 0;
 			$this->resetMotion();
+			$riddenByEntity->y = $pos->y;
 
 			$this->velocity->setComponents(0, 0, 0);
 		}else{

--- a/src/pocketmine/entity/vehicle/Boat.php
+++ b/src/pocketmine/entity/vehicle/Boat.php
@@ -26,6 +26,7 @@ namespace pocketmine\entity\vehicle;
 
 use pocketmine\block\Water;
 use pocketmine\entity\Entity;
+use pocketmine\entity\PlayerInventoryMount;
 use pocketmine\entity\Vehicle;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
@@ -38,7 +39,7 @@ use pocketmine\network\mcpe\protocol\SetActorLinkPacket;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
 use pocketmine\Player;
 
-class Boat extends Vehicle{
+class Boat extends Vehicle implements PlayerInventoryMount{
 	public const NETWORK_ID = self::BOAT;
 
 	public const TAG_VARIANT = "Variant";

--- a/src/pocketmine/entity/vehicle/Minecart.php
+++ b/src/pocketmine/entity/vehicle/Minecart.php
@@ -24,12 +24,13 @@ declare(strict_types=1);
 
 namespace pocketmine\entity\vehicle;
 
+use pocketmine\entity\PlayerInventoryMount;
 use pocketmine\entity\Vehicle;
 use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\math\Vector3;
 
-class Minecart extends Vehicle{
+class Minecart extends Vehicle implements PlayerInventoryMount{
 	public const NETWORK_ID = self::MINECART;
 
 	public $height = 0.7;


### PR DESCRIPTION
- allow player inventory on mounts without container
- prevent air bubbles/drowning when riding boat